### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,13 @@ branches:
 matrix:
     fast_finish: true
     include:
+        - php: 7.3
+        - php: 7.2
         - php: 7.1
         - php: 7.0
         - php: 5.6
         - php: 5.5
-        - php: hhvm
-          sudo: required
           dist: trusty
-          group: edge
 
 before_install:
     - if [ "$TRAVIS_PHP_VERSION" = "hhvm" ]; then echo 'xdebug.enable = on' >> /etc/hhvm/php.ini; fi

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
         "gpslab/cqrs": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8",
+        "phpunit/phpunit": "^4.8.36",
         "scrutinizer/ocular": "~1.3",
-        "satooshi/php-coveralls": "^1.0"
+        "php-coveralls/php-coveralls": "^1.0"
     }
 }

--- a/tests/ObviousSpecificationQueryTest.php
+++ b/tests/ObviousSpecificationQueryTest.php
@@ -11,8 +11,9 @@
 namespace GpsLab\Component\Query\Specification;
 
 use Happyr\DoctrineSpecification\Spec;
+use PHPUnit\Framework\TestCase;
 
-class ObviousSpecificationQueryTest extends \PHPUnit_Framework_TestCase
+class ObviousSpecificationQueryTest extends TestCase
 {
     public function testHasModifier()
     {

--- a/tests/SpecificationQueryHandlerTest.php
+++ b/tests/SpecificationQueryHandlerTest.php
@@ -13,8 +13,9 @@ namespace GpsLab\Component\Query\Specification;
 use Doctrine\ORM\EntityManagerInterface;
 use Happyr\DoctrineSpecification\EntitySpecificationRepositoryInterface;
 use Happyr\DoctrineSpecification\Spec;
+use PHPUnit\Framework\TestCase;
 
-class SpecificationQueryHandlerTest extends \PHPUnit_Framework_TestCase
+class SpecificationQueryHandlerTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|EntityManagerInterface


### PR DESCRIPTION
# Changed log
- Add other `php-7.x` versions during Travis CI build.
- To be compatible with future PHPUnit versions, using the `PHPUnit\Framework\TestCase` namespace instead.
- The `satooshi/php-coveralls` package is deprecated and using the `php-coveralls/php-coveralls` instead.